### PR TITLE
Removed link to ACH External Transfer Service as it is not available …

### DIFF
--- a/docs/fintechs/transfers.md
+++ b/docs/fintechs/transfers.md
@@ -9,7 +9,6 @@ Transfers is an API domain consisting of funds transfer-related APIs. Specific t
 **Potential uses:** App that facilitate enterprise disbursements such as merchant rebates, loyalty rewards, employee bonuses, expense reimbursements, loan payouts and so forth or on-demand service apps that serve fast-growing services markets such as ride share, grocery or food delivery, digital insurers, travel, vacation and other industries that require the ability to move money
 
 Begin the integration with the following services from the Transfers domain in API Explorer:
-* [ACH External Transfer Service](../api/?type=post&path=/achextacctxferservice/acctmgmt/achextacctxfer)
 * [Transfer Service](../api/?type=post&path=/xferservice/payments/transfers)
 
 


### PR DESCRIPTION
…on portal.

We removed that as per the ask by Rahul and confirmation by Fabiola. Refer to the commit in tenant.json on April 10, 2024 by Mayuri.